### PR TITLE
Added support for block reading and writing

### DIFF
--- a/src/i2c-dev.c
+++ b/src/i2c-dev.c
@@ -70,4 +70,38 @@ extern inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value) {
 	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_WORD_DATA, &data);
 }
 
+extern inline __s32 i2c_smbus_read_data_block(int fd, int cmd, unsigned char *block, int block_size) {
+	union i2c_smbus_data data;
+	if (block_size > I2C_SMBUS_BLOCK_MAX) {
+		block_size = I2C_SMBUS_BLOCK_MAX;
+	}
+	data.block[0] = block_size;
+	if(i2c_smbus_access(fd, I2C_SMBUS_READ, cmd, I2C_SMBUS_I2C_BLOCK_DATA, &data) < 0) {
+		return -1;
+	} else {
+		memcpy(block, data.block+1, block_size);
+		return data.block[0];
+	}
+}
+
+extern inline __s32 i2c_smbus_write_data_block(int fd, int cmd, unsigned char *block, int block_size) {
+	union i2c_smbus_data data;
+	if (block_size > I2C_SMBUS_BLOCK_MAX) {
+		block_size = I2C_SMBUS_BLOCK_MAX;
+	}
+	data.block[0] = block_size;
+	memcpy(data.block+1, block, block_size);
+	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_I2C_BLOCK_BROKEN, &data);
+}
+
+extern inline __s32 i2c_smbus_write_data_block_with_size(int fd, int cmd, unsigned char *block, int block_size) {
+	union i2c_smbus_data data;
+	if (block_size > I2C_SMBUS_BLOCK_MAX) {
+		block_size = I2C_SMBUS_BLOCK_MAX;
+	}
+	data.block[0] = block_size;
+	memcpy(data.block+1, block, block_size);
+	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_I2C_BLOCK_DATA, &data);
+}
+
 #endif

--- a/src/i2c-dev.h
+++ b/src/i2c-dev.h
@@ -34,5 +34,9 @@ inline __s32 i2c_smbus_read_byte_data(int fd, int cmd);
 inline __s32 i2c_smbus_write_byte_data(int fd, int cmd, int value);
 inline __s32 i2c_smbus_read_word_data(int fd, int cmd);
 inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value);
+inline __s32 i2c_smbus_read_data_block(int fd, int cmd, unsigned char *block, int block_size);
+inline __s32 i2c_smbus_write_data_block(int fd, int cmd, unsigned char *block, int block_size);
+inline __s32 i2c_smbus_write_data_block_with_size(int fd, int cmd, unsigned char *block, int block_size);
+
 
 #endif

--- a/src/wiringx.c
+++ b/src/wiringx.c
@@ -126,8 +126,8 @@ static void delayMicrosecondsHard(unsigned int howLong) {
 	tLong.tv_sec  = howLong / 1000000;
 	tLong.tv_usec = howLong % 1000000;
 #else
-	tLong.tv_sec  = (__time_t)howLong / 1000000;
-	tLong.tv_usec = (__suseconds_t)howLong % 1000000;
+	tLong.tv_sec  = (time_t)howLong / 1000000;
+	tLong.tv_usec = (suseconds_t)howLong % 1000000;
 #endif
 	timeradd(&tNow, &tLong, &tEnd);
 
@@ -142,7 +142,7 @@ EXPORT void delayMicroseconds(unsigned int howLong) {
 	long int uSecs = howLong % 1000000;
 	unsigned int wSecs = howLong / 1000000;
 #else
-	long int uSecs = (__time_t)howLong % 1000000;
+	long int uSecs = (time_t)howLong % 1000000;
 	unsigned int wSecs = howLong / 1000000;
 #endif
 
@@ -154,7 +154,7 @@ EXPORT void delayMicroseconds(unsigned int howLong) {
 #ifdef _WIN32
 		sleeper.tv_sec = wSecs;
 #else
-		sleeper.tv_sec = (__time_t)wSecs;	
+		sleeper.tv_sec = (time_t)wSecs;	
 #endif
 		sleeper.tv_nsec = (long)(uSecs * 1000L);
 		nanosleep(&sleeper, NULL);
@@ -398,6 +398,10 @@ EXPORT int wiringXI2CReadReg16(int fd, int reg) {
 	return i2c_smbus_read_word_data(fd, reg);
 }
 
+EXPORT int wiringXI2CReadBlockData(int fd, int reg, unsigned char *block, int block_size) {
+	return i2c_smbus_read_data_block(fd, reg, block, block_size);
+}
+
 EXPORT int wiringXI2CWrite(int fd, int data) {
 	return i2c_smbus_write_byte(fd, data);
 }
@@ -408,6 +412,14 @@ EXPORT int wiringXI2CWriteReg8(int fd, int reg, int data) {
 
 EXPORT int wiringXI2CWriteReg16(int fd, int reg, int data) {
 	return i2c_smbus_write_word_data(fd, reg, data);
+}
+
+EXPORT int wiringXI2CWriteBlockData(int fd, int reg, unsigned char *block, int block_size) {
+	return i2c_smbus_write_data_block(fd, reg, block, block_size);
+}
+
+EXPORT int wiringXI2CWriteBlockDataWithSize(int fd, int reg, unsigned char *block, int block_size) {
+	return i2c_smbus_write_data_block_with_size(fd, reg, block, block_size);
 }
 
 EXPORT int wiringXI2CSetup(const char *path, int devId) {

--- a/src/wiringx.h
+++ b/src/wiringx.h
@@ -80,9 +80,12 @@ int wiringXISR(int, enum isr_mode_t);
 int wiringXI2CRead(int);
 int wiringXI2CReadReg8(int, int);
 int wiringXI2CReadReg16(int, int);
+int wiringXI2CReadBlockData(int, int, unsigned char*, int);
 int wiringXI2CWrite(int, int);
 int wiringXI2CWriteReg8(int, int, int);
 int wiringXI2CWriteReg16(int, int, int);
+int wiringXI2CWriteBlockData(int, int, unsigned char*, int);
+int wiringXI2CWriteBlockDataWithSize(int, int, unsigned char*, int);
 int wiringXI2CSetup(const char *, int);
 
 int wiringXSPIGetFd(int channel);


### PR DESCRIPTION
Hello there,

Thanks for all the great work with the Milk-V boards. It's been very fun working with them :)

I added three functions to support reading and writing blocks with a specified size to the I2C device. This can particularly be useful if a slave device replies back with a `DWORD` (e.g., one of its registers is 32-bit). For writing, I added two versions, one that implicitly sends the size as the first byte to the slave device and one that doesn't.

I tested these changes on the Milk-V Duo S running the [latest image](https://github.com/milkv-duo/duo-buildroot-sdk/releases/tag/Duo-V1.1.2) and it works fine. All I need to do is replace `/usr/lib/libwiringx.so` on the Milk-V with the new binary and include it in the sdk toolchain as well.

I also replaced `__time_t` and `__suseconds_t` with `time_t` and `suseconds_t`, respectively. This allows it to be cross-compiled for rv64 with musl.

Thanks!